### PR TITLE
Fix traceback info for nested exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.egg-info
+__pycache__
+**/logs/**

--- a/logger_tt/inspector.py
+++ b/logger_tt/inspector.py
@@ -256,6 +256,15 @@ def parse_full_context(identifiers, frame) -> list:
                for k, v in local_var.items() if k in other_local_var]
     return txt
 
+def analyze_exception_recur(e:BaseException, full_context: int, limit_line_length: int, analyze_raise_statement: bool, text:str='') -> str:
+    cause = e.__cause__ or e.__context__
+    if cause:
+        text = analyze_exception_recur(cause, full_context, limit_line_length, analyze_raise_statement,text) \
+             + '\nDuring handling of the above exception, another exception occurred:\n\n'
+    text += ("Traceback (most recent call last):\n" \
+         + analyze_frame(e.__traceback__, full_context, limit_line_length, analyze_raise_statement) \
+         + f'{type(e).__name__}: {e}\n')
+    return text
 
 def analyze_frame(trace_back, full_context: int, limit_line_length: int, analyze_raise_statement: bool) -> str:
     """

--- a/tests/exception_on_exception.py
+++ b/tests/exception_on_exception.py
@@ -9,17 +9,17 @@ logger = getLogger(__name__)
 
 def foo():
     try:
-        a,b=1,0
-        a/b
+        a=1
+        raise RuntimeError(a)
     except:
         try:
-            c,d=1,0
-            c/d
+            b=2
+            raise RuntimeError(b)
         except:
-            e,f=1,0
-            e/f
+            c=3
+            raise RuntimeError(c)
 
-if __name__ == '__main__':
+def main():
     logger.info('========A Caught Exception===========')
     try:
         foo()
@@ -27,3 +27,6 @@ if __name__ == '__main__':
         logger.exception('Caught exception:')
     logger.info('=======An Uncaught Exception=========')
     foo()
+
+if __name__ == '__main__':
+    main()

--- a/tests/exception_on_exception.py
+++ b/tests/exception_on_exception.py
@@ -1,5 +1,6 @@
-import time
+import sys
 from logging import getLogger
+
 from logger_tt import setup_logging
 
 __author__ = "ZeroRin"
@@ -19,14 +20,14 @@ def foo():
             c=3
             raise RuntimeError(c)
 
-def main():
-    logger.info('========A Caught Exception===========')
-    try:
-        foo()
-    except:
-        logger.exception('Caught exception:')
-    logger.info('=======An Uncaught Exception=========')
-    foo()
-
 if __name__ == '__main__':
-    main()
+    match sys.argv[-1]:
+        case 'caught':
+            try:
+                foo()
+            except:
+                logger.exception('Caught exception:')
+        case 'uncaught':
+            foo()
+        case _:
+            raise ValueError('Usage [PROG] {caught,uncaught}')

--- a/tests/exception_on_exception.py
+++ b/tests/exception_on_exception.py
@@ -1,0 +1,29 @@
+import time
+from logging import getLogger
+from logger_tt import setup_logging
+
+__author__ = "ZeroRin"
+
+setup_logging(analyze_raise_statement=True)
+logger = getLogger(__name__)
+
+def foo():
+    try:
+        a,b=1,0
+        a/b
+    except:
+        try:
+            c,d=1,0
+            c/d
+        except:
+            e,f=1,0
+            e/f
+
+if __name__ == '__main__':
+    logger.info('========A Caught Exception===========')
+    try:
+        foo()
+    except:
+        logger.exception('Caught exception:')
+    logger.info('=======An Uncaught Exception=========')
+    foo()

--- a/tests/exception_on_exception.py
+++ b/tests/exception_on_exception.py
@@ -21,13 +21,12 @@ def foo():
             raise RuntimeError(c)
 
 if __name__ == '__main__':
-    match sys.argv[-1]:
-        case 'caught':
-            try:
-                foo()
-            except:
-                logger.exception('Caught exception:')
-        case 'uncaught':
+    if sys.argv[-1] == 'caught':
+        try:
             foo()
-        case _:
-            raise ValueError('Usage [PROG] {caught,uncaught}')
+        except:
+            logger.exception('Caught exception:')
+    elif sys.argv[-1] ==  'uncaught':
+        foo()
+    else:
+        raise ValueError('Usage [PROG] {caught,uncaught}')

--- a/tests/test_recur_exception.py
+++ b/tests/test_recur_exception.py
@@ -31,12 +31,16 @@ Traceback \(most recent call last\):
      |-> c = 3
 RuntimeError: 3'''
 
-def test_recur_exception():
-    for case in ['caught', 'uncaught']:
-        cmd = [sys.executable, "exception_on_exception.py", case]
-        run(cmd)
-
+def test_recur_exception_caught():
+    cmd = [sys.executable, "exception_on_exception.py", "caught"]
+    run(cmd)
     data = log.read_text()
-    pattern = rf'Caught exception\n{TRACE}[\S\s\n]*Uncaught exception\n{TRACE}'
-    
+    pattern = rf'Caught exception\n{TRACE}'
+    assert re.search(pattern, data, re.DOTALL)
+
+def test_recur_exception_uncaught():
+    cmd = [sys.executable, "exception_on_exception.py", "uncaught"]
+    run(cmd)
+    data = log.read_text()
+    pattern = rf'Uncaught exception\n{TRACE}'
     assert re.search(pattern, data, re.DOTALL)

--- a/tests/test_recur_exception.py
+++ b/tests/test_recur_exception.py
@@ -1,0 +1,60 @@
+import re
+import sys
+import time
+from pathlib import Path
+from subprocess import run, PIPE
+import pytest
+import re
+from logger_tt.inspector import get_recur_attr, get_repr, is_full_statement, get_full_statement, MEM_PATTERN
+
+__author__ = "ZeroRin"
+log = Path.cwd() / 'logs/log.txt'
+
+
+def test_recur_exception():
+    cmd = [sys.executable, "exception_on_exception.py"]
+    run(cmd)
+    data = log.read_text()
+    pattern = (
+        r'Caught exception:\n'
+        r'Traceback \(most recent call last\):'
+        r'[\S\s]*'
+        r'raise RuntimeError\(a\)'
+        r'[\S\s]*'
+        r'RuntimeError: 1\n\n'
+        r'During handling of the above exception, another exception occurred:\n\n'
+        r'Traceback \(most recent call last\):'
+        r'[\S\s]*'
+        r'raise RuntimeError\(b\)'
+        r'[\S\s]*'
+        r'RuntimeError: 2\n\n'
+        r'During handling of the above exception, another exception occurred:\n\n'
+        r'Traceback \(most recent call last\):'
+        r'[\S\s]*'
+        r'raise RuntimeError\(c\)'
+        r'[\S\s]*'
+        r'RuntimeError: 3'
+        r'[\S\s]*'
+        r'Uncaught exception:\n'
+        r'Traceback \(most recent call last\):'
+        r'[\S\s]*'
+        r'raise RuntimeError\(a\)'
+        r'[\S\s]*'
+        r'RuntimeError: 1\n\n'
+        r'During handling of the above exception, another exception occurred:\n\n'
+        r'Traceback \(most recent call last\):'
+        r'[\S\s]*'
+        r'raise RuntimeError\(b\)'
+        r'[\S\s]*'
+        r'RuntimeError: 2\n\n'
+        r'During handling of the above exception, another exception occurred:\n\n'
+        r'Traceback \(most recent call last\):'
+        r'[\S\s]*'
+        r'raise RuntimeError\(c\)'
+        r'[\S\s]*'
+        r'RuntimeError: 3'
+        r'[\S\s]*'
+    )
+    assert re.search(pattern,data)
+
+test_recur_exception()


### PR DESCRIPTION
Related to #14 where the logging for exception raised in another exception is not logged in proper form.
Created a `analyze_exception_recur` function that traverse through the cause of the exception and call the original `analyze_frame` for each cause to generate the proper logging. Also created a test example.
