### PR TITLE
Fix non-`%`-style formatting

### DIFF
--- a/logger_tt/core.py
+++ b/logger_tt/core.py
@@ -125,6 +125,7 @@ class LogConfig:
             # add queue handler
             queue = self.qclass()
             q_handler = handlers.QueueHandler(queue)
+            q_handler.setFormatter(all_handlers[0].formatter)
             logger.addHandler(q_handler)
             self.__middle_handlers.append(q_handler)
 
@@ -376,7 +377,7 @@ class DefaultFormatter(logging.Formatter):
                            both=["%(message)s", "%(processName)s %(threadName)s %(message)s"])
 
     def __init__(self, fmt: str = '', datefmt: str = '', style: str = ''):
-        super(DefaultFormatter, self).__init__(fmt=fmt, datefmt=datefmt)
+        super(DefaultFormatter, self).__init__(fmt=fmt, datefmt=datefmt, style=style)
 
         self._logger_tt_formatters = {}
         for case, fmt in self._standardize(fmt).items():
@@ -386,7 +387,7 @@ class DefaultFormatter(logging.Formatter):
         formatters = {'normal': fmt.replace(self.default_formats['normal'][0], self.default_formats['normal'][1])}
 
         # concurrent format
-        concurrent_fmt = formatters['normal'].replace('%(threadName)s', '').replace('%(processName)s', '')
+        concurrent_fmt = formatters['normal'].replace('%(threadName)s', '').replace('%(processName)s', '').replace('{threadName}', '').replace('{processName}', '')
         for _type, replacement in self.default_formats.items():
             if _type == 'normal':
                 continue

--- a/tests/test_brace_style.py
+++ b/tests/test_brace_style.py
@@ -1,0 +1,37 @@
+from logging import getLogger
+from pathlib import Path
+
+import pytest
+from logger_tt import setup_logging
+
+__author__ = "nonnull"
+
+logger = getLogger(__name__)
+log = Path.cwd() / 'logs/log.txt'
+
+def test_basic_brace_style(capsys):
+    with setup_logging(config_path="test_brace_style.yaml"):
+        logger.debug('my %s', 'debug')
+        logger.info('my %s', 'info')
+        logger.warning('my %s', 'warning')
+        logger.error('my %s', 'error')
+        logger.critical('the market %s', 'crashed')
+
+    # check stdout
+    captured = capsys.readouterr()
+    stdout_data = captured.out
+    stderr_data = captured.err
+    assert '--- Logging error ---' not in stderr_data, stderr_data
+    assert 'my debug' not in stdout_data, stdout_data
+    assert 'INFO: my info' in stdout_data, stdout_data
+    assert 'WARNING: my warning' in stdout_data, stdout_data
+    assert 'ERROR: my error' in stdout_data, stdout_data
+    assert 'CRITICAL: the market crashed' in stdout_data, stdout_data
+
+    # check log.txt
+    log_data = log.read_text()
+    assert 'DEBUG] my debug' in log_data
+    assert 'INFO] my info' in log_data
+    assert 'WARNING] my warning' in log_data
+    assert 'ERROR] my error' in log_data
+    assert 'CRITICAL] the market crashed' in log_data

--- a/tests/test_brace_style.yaml
+++ b/tests/test_brace_style.yaml
@@ -1,0 +1,79 @@
+# This is an example of config file
+# In case of no config provided, log_config.json file will be loaded
+# If you need a yaml file, install pyyaml package and copy this file
+version: 1
+disable_existing_loggers: False
+formatters:
+  simple:
+    style: '{'
+    format: "[{asctime}] [{name}:{lineno} {levelname}] {message}"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+  brief:
+    style: '{'
+    format: "[{asctime}] {levelname}: {message}"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    level: INFO
+    formatter: brief
+    stream: ext://sys.stdout
+
+  error_file_handler:
+    class: logging.handlers.TimedRotatingFileHandler
+    level: DEBUG
+    formatter: simple
+    filename: logs/log.txt
+    backupCount: 15
+    encoding: utf8
+    when: midnight
+    delay: True
+
+  buffer_stream_handler:
+    class: logger_tt.handlers.StreamHandlerWithBuffer
+    level: DEBUG
+    formatter: brief
+    stream: ext://sys.stdout
+    buffer_time: 0.5
+    buffer_lines: 0
+    debug: False
+
+  telegram_handler:
+    class: logger_tt.handlers.TelegramHandler
+    level: NOTICE
+    formatter: brief
+    debug: False
+    token: "your bot token here or set the below env key to fetch from environ for better security"
+    unique_ids: "semicolon separated of [name:]chat_id[@message_thread_id]"
+    env_token_key: "TELEGRAM_BOT_LOG_TOKEN"
+    env_unique_ids_key: "TELEGRAM_BOT_LOG_DEST"
+
+
+loggers:
+  urllib3:
+    level: WARNING
+    handlers: [console, error_file_handler]
+    propagate: no
+
+root:
+  level: DEBUG
+  handlers: [console, error_file_handler]
+
+logger_tt:
+  suppress: ["exchangelib"]
+  suppress_level_below: "WARNING"
+  capture_print: False
+  strict: False
+  guess_level: False
+  full_context: 0
+  use_multiprocessing: False
+  limit_line_length: 1000
+  analyze_raise_statement: False
+  host: ""
+  port: 0
+  default_logger_formats:
+    normal: ["{name}", "{filename}"]
+    thread: ["{message}", "{threadName} {message}"]
+    multiprocess: ["{message}", "{processName} {message}"]
+    both: ["{message}", "{processName} {threadName} {message}"]


### PR DESCRIPTION
I dug into #22 a little, and it appears as though the problem is [here](https://github.com/Dragon2fly/logger_tt/blob/master/logger_tt/core.py#L379):

```python
    def __init__(self, fmt: str = '', datefmt: str = '', style: str = ''):
        super(DefaultFormatter, self).__init__(fmt=fmt, datefmt=datefmt)

        self._logger_tt_formatters = {}
        for case, fmt in self._standardize(fmt).items():
            self._logger_tt_formatters[case] = logging.Formatter(fmt=fmt, datefmt=datefmt, style=style)
```
Note that the initial super() call does not pass along `style`, but then it passes the same `fmt` into the underlying `logging.Formatters` with `style`. Then then results in the same format string being interpreted as `%`-style and `{`-style in different places.