### PR TITLE
Fix hardcoded traceback path in test_inspector.test_py_311

### DIFF
--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -243,20 +243,21 @@ def test_py_311():
     run(cmd)
 
     expected_traceback = r"""Traceback (most recent call last):
-  File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 30, in <module>
+  File "PATH", line 30, in <module>
     lel3(xx)
 
-  File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 25, in lel3
+  File "PATH", line 25, in lel3
     return lel2(x) / 23
            ^^^^^^^
 
-  File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 21, in lel2
+  File "PATH", line 21, in lel2
     return 25 + lel(x) + lel(x)
                 ^^^^^^
 
-  File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 17, in lel
+  File "PATH", line 17, in lel
     return 1 + foo(a, b, c=x['z']['x']['y']['z']['y'], d=e)
                            ~~~~~~~~~~~~~~~~^^^^^"""
+    expected_traceback = re.escape(expected_traceback).replace("PATH", '[^"]*exception_main_py311[.]py')
 
     data = log.read_text()
-    assert expected_traceback in data
+    assert re.search(expected_traceback, data)


### PR DESCRIPTION
```
$ git checkout origin/master
HEAD is now at ef5a97d version bump to 1.7.3
$ pytest -k test_py_311
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.11.2, pytest-7.1.2, pluggy-1.0.0
rootdir: [...]/logger_tt
plugins: xdist-3.2.1, hypothesis-6.29.3
collected 68 items / 67 deselected / 1 selected                                                                                                                                    

test_inspector.py F                                                                                                                                                          [100%]

===================================================================================== FAILURES =====================================================================================
___________________________________________________________________________________ test_py_311 ____________________________________________________________________________________

    @pytest.mark.skipif(sys.version_info < (3, 11), reason="traceback annotation is only supported on py 3.11+")
    def test_py_311():
        cmd = [sys.executable, "exception_main_py311.py"]
        run(cmd)
    
        expected_traceback = r"""Traceback (most recent call last):
      File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 30, in <module>
        lel3(xx)
    
      File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 25, in lel3
        return lel2(x) / 23
               ^^^^^^^
    
      File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 21, in lel2
        return 25 + lel(x) + lel(x)
                    ^^^^^^
    
      File "D:\pycharm_projects\logger_tt\tests\exception_main_py311.py", line 17, in lel
        return 1 + foo(a, b, c=x['z']['x']['y']['z']['y'], d=e)
                               ~~~~~~~~~~~~~~~~^^^^^"""
    
        data = log.read_text()
>       assert expected_traceback in data
E       assert 'Traceback (most recent call last):\n  File "D:\\pycharm_projects\\logger_tt\\tests\\exception_main_py311.py", line 30...   return 1 + foo(a, b, c=x[\'z\'][\'x\'][\'y\'][\'z\'][\'y\'], d=e)\n                           ~~~~~~~~~~~~~~~~^^^^^' in "[2023-05-06 21:46:57] [root:220 DEBUG] _________________New log started__________________\n[2023-05-06 21:46:57] [roo...> b = 2\n     |-> x = {'z': {'x': {'y': None}}}\n     |-> e = 4\nTypeError: 'NoneType' object is not subscriptable\n\n"

test_inspector.py:262: AssertionError
------------------------------------------------------------------------------- Captured stdout call -------------------------------------------------------------------------------
[2023-05-06 21:46:57] ERROR: Uncaught exception:
Traceback (most recent call last):
  File "[...]/tests/exception_main_py311.py", line 30, in <module>
    lel3(xx)

  File "[...]/tests/exception_main_py311.py", line 25, in lel3
    return lel2(x) / 23
           ^^^^^^^

  File "[...]/tests/exception_main_py311.py", line 21, in lel2
    return 25 + lel(x) + lel(x)
                ^^^^^^

  File "[...]/tests/exception_main_py311.py", line 17, in lel
    return 1 + foo(a, b, c=x['z']['x']['y']['z']['y'], d=e)
                           ~~~~~~~~~~~~~~~~^^^^^
     |-> (outer) foo = <function foo at [...]>
     |-> a = 1
     |-> b = 2
     |-> x = {'z': {'x': {'y': None}}}
     |-> e = 4
TypeError: 'NoneType' object is not subscriptable

============================================================================= short test summary info ==============================================================================
FAILED test_inspector.py::test_py_311 - assert 'Traceback (most recent call last):\n  File "D:\\pycharm_projects\\logger_tt\\tests\\exception_main_py311.py", line 30...   return...
========================================================================= 1 failed, 67 deselected in 1.56s =========================================================================
$ git checkout pytest
Previous HEAD position was ef5a97d version bump to 1.7.3
Switched to branch 'pytest'
Your branch is up to date with 'origin/pytest'.
$ pytest -k test_py_311
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.11.2, pytest-7.1.2, pluggy-1.0.0
rootdir: [...]/logger_tt
plugins: xdist-3.2.1, hypothesis-6.29.3
collected 68 items / 67 deselected / 1 selected                                                                                                                                    

test_inspector.py .                                                                                                                                                          [100%]

========================================================================= 1 passed, 67 deselected in 1.27s =========================================================================
```