### PR TITLE
fix: modify root.handlers inplace in remove_unused_handlers

### DIFF
--- a/logger_tt/__init__.py
+++ b/logger_tt/__init__.py
@@ -143,7 +143,7 @@ def remove_unused_handlers(config: dict):
         This is to prevent side effect of creating a handler but it is not used.
     """
     all_handlers = list(config['handlers'])
-    used_handlers = config['root']['handlers']
+    used_handlers = list(config['root']['handlers'])
     for name in config['loggers']:
         handlers = config['loggers'][name]["handlers"]
         used_handlers.extend(handlers)


### PR DESCRIPTION
the original code append handlers from all loggers to the root logger. handlers configured to respond to certain module only will be trigger by the root handler as a result.

fixed it by simply adding a `list(...)` outside, so it creates a copy of the root handler list 